### PR TITLE
Add bluebird to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "test": "mocha"
   },
   "main": "src/index.js",
+  "dependencies": {
+    "bluebird": "^3.3.1"
+  },
   "devDependencies": {
     "bluebird": "^3.3.1",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
Running `npm install node-opencc` in other package doesn't install bluebird which is required by  node-opencc because it's in `devDependencies`. So I added it to `dependencies` field in `package.json` to solve this problem.
